### PR TITLE
Changes pybel import

### DIFF
--- a/mdaCIF.py
+++ b/mdaCIF.py
@@ -12,7 +12,7 @@ from MDAnalysis.core.topologyattrs import (
     Segids,
 )
 
-import pybel
+from openbabel import pybel
 import openbabel
 fillUC = openbabel.OBOp.FindType('fillUC')
 


### PR DESCRIPTION
I found this small script useful. This change adds compatibility with openbabel 3.0 as the import for pybel was changed from `import pybel` to `from openbabel import pybel`.  https://github.com/openbabel/openbabel/pull/1946 

